### PR TITLE
fix: Handle missing artifact on first run of CD pipeline

### DIFF
--- a/.github/workflows/dbt-cd-pipeline.yml
+++ b/.github/workflows/dbt-cd-pipeline.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Download prod manifest
         uses: Legit-Labs/action-download-artifact@v2
+        continue-on-error: true
         with:
           name: dbt-manifest-prod
           path: prod-artifacts


### PR DESCRIPTION
This commit fixes an issue where the CD pipeline would fail on its first run due to a missing `dbt-manifest-prod` artifact.

The `Legit-Labs/action-download-artifact` action was failing because it could not find the artifact to download. This is expected on the first run.

The fix is to add `continue-on-error: true` to the download step. This allows the workflow to continue, and the subsequent logic already handles the case where the artifact is not present by running a full `dbt build`.